### PR TITLE
Issue #17 - Only show the switch being on if generator is in use

### DIFF
--- a/src/mobilelink-accessory.ts
+++ b/src/mobilelink-accessory.ts
@@ -176,7 +176,7 @@ export class MobileLinkAccessory {
 
       try {
         this.service.getCharacteristic(this.Characteristic.Name).updateValue(this.apparatus.name);
-        this.service.getCharacteristic(this.Characteristic.On).updateValue(this.isReady());
+        this.service.getCharacteristic(this.Characteristic.On).updateValue(this.isRunning());
         this.service.getCharacteristic(this.Characteristic.OutletInUse).updateValue(this.isRunning());
 
         this.batteryService.getCharacteristic(this.Characteristic.BatteryLevel).updateValue(this.getBatteryLevel());


### PR DESCRIPTION
Per https://github.com/drudge/homebridge-mobilelink/issues/17 you can't do HomeKit automations based on "inUse" only if a switch turns on or off.  This only shows the generator switch on if it's actually running